### PR TITLE
chore: release v0.4.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.9](https://github.com/nyurik/delta-encoding/compare/v0.4.8...v0.4.9) - 2025-06-11
+
+### Other
+
+- use release-plz token in dependabot ci
+
 ## [0.4.8](https://github.com/nyurik/delta-encoding/compare/v0.4.7...v0.4.8) - 2025-06-08
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "delta-encoding"
-version = "0.4.8"
+version = "0.4.9"
 description = "A library to encode and decode a delta-encoded stream of numbers"
 authors = ["Yuri Astrakhan <YuriAstrakhan@gmail.com>"]
 repository = "https://github.com/nyurik/delta-encoding"


### PR DESCRIPTION



## 🤖 New release

* `delta-encoding`: 0.4.8 -> 0.4.9 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.9](https://github.com/nyurik/delta-encoding/compare/v0.4.8...v0.4.9) - 2025-06-11

### Other

- use release-plz token in dependabot ci
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).