### PR TITLE
chore: release v0.4.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.11](https://github.com/nyurik/delta-encoding/compare/v0.4.10...v0.4.11) - 2026-04-21
+
+### Other
+
+- *(deps)* bump the all-actions-version-updates group across 1 directory with 2 updates ([#35](https://github.com/nyurik/delta-encoding/pull/35))
+- *(deps)* update criterion requirement from 0.7 to 0.8 in the all-cargo-version-updates group ([#36](https://github.com/nyurik/delta-encoding/pull/36))
+- [pre-commit.ci] pre-commit autoupdate ([#33](https://github.com/nyurik/delta-encoding/pull/33))
+- add .editorconfig, minor cleanups ([#32](https://github.com/nyurik/delta-encoding/pull/32))
+- add .editorconfig
+- *(deps)* bump actions/checkout from 5 to 6 in the all-actions-version-updates group ([#29](https://github.com/nyurik/delta-encoding/pull/29))
+- minor justfile adjustments
+
 ## [0.4.10](https://github.com/nyurik/delta-encoding/compare/v0.4.9...v0.4.10) - 2025-11-10
 
 ### Other

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "delta-encoding"
-version = "0.4.10"
+version = "0.4.11"
 description = "A library to encode and decode a delta-encoded stream of numbers"
 authors = ["Yuri Astrakhan <YuriAstrakhan@gmail.com>"]
 repository = "https://github.com/nyurik/delta-encoding"


### PR DESCRIPTION



## 🤖 New release

* `delta-encoding`: 0.4.10 -> 0.4.11 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.11](https://github.com/nyurik/delta-encoding/compare/v0.4.10...v0.4.11) - 2026-08-18

### Other

- [pre-commit.ci] pre-commit autoupdate ([#41](https://github.com/nyurik/delta-encoding/pull/41))
- fix justfile cargo binstall
- let rust fmt indent .rs files
- disallow mem leaking in code
- ignore CARGO_BUILD_WARNINGS in cargo-install
- use Rust 1.97 cargo warnings
- update .gitignore
- format justfile
- *(deps)* bump actions/checkout from 6 to 7 in the all-actions-version-updates group ([#39](https://github.com/nyurik/delta-encoding/pull/39))
- coverage, justfile, msrv ([#38](https://github.com/nyurik/delta-encoding/pull/38))
- *(deps)* bump codecov/codecov-action from 6 to 7 in the all-actions-version-updates group ([#37](https://github.com/nyurik/delta-encoding/pull/37))
- *(deps)* bump the all-actions-version-updates group across 1 directory with 2 updates ([#35](https://github.com/nyurik/delta-encoding/pull/35))
- *(deps)* update criterion requirement from 0.7 to 0.8 in the all-cargo-version-updates group ([#36](https://github.com/nyurik/delta-encoding/pull/36))
- [pre-commit.ci] pre-commit autoupdate ([#33](https://github.com/nyurik/delta-encoding/pull/33))
- add .editorconfig, minor cleanups ([#32](https://github.com/nyurik/delta-encoding/pull/32))
- add .editorconfig
- *(deps)* bump actions/checkout from 5 to 6 in the all-actions-version-updates group ([#29](https://github.com/nyurik/delta-encoding/pull/29))
- minor justfile adjustments
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).